### PR TITLE
Add menu to select available fields and render in side bar

### DIFF
--- a/app/src/features/ApplicationWorkspace/AddFieldButton.tsx
+++ b/app/src/features/ApplicationWorkspace/AddFieldButton.tsx
@@ -1,0 +1,26 @@
+import {Add} from '@mui/icons-material';
+import {Button, Tooltip} from '@mui/material';
+
+export const AddFieldButton = () => {
+  return (
+    <Tooltip title="Add content field" placement="top">
+      <Button
+        variant="contained"
+        sx={{
+          backgroundColor: 'rgba(0, 0, 0, 1)',
+          borderRadius: '8px',
+          p: 1,
+          minWidth: 'auto',
+          color: 'palette.common.white',
+          '&:hover': {
+            backgroundColor: 'rgba(0, 0, 0, 0.8)',
+          },
+        }}
+        aria-label="Add Content"
+        size="small"
+      >
+        <Add sx={{height: '18px'}} />
+      </Button>
+    </Tooltip>
+  );
+};

--- a/app/src/features/ApplicationWorkspace/AddFieldButton.tsx
+++ b/app/src/features/ApplicationWorkspace/AddFieldButton.tsx
@@ -4,14 +4,22 @@ import {useState} from 'react';
 
 import {Tooltip} from '../Common';
 import {AddFieldMenu} from './AddFieldMenu';
+import {FieldTypes} from './constants';
 
-export const AddFieldButton = () => {
+interface AddFieldButtonProps {
+  addField: (field: FieldTypes) => void;
+}
+
+export const AddFieldButton = ({addField}: AddFieldButtonProps) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const isOpen = Boolean(anchorEl);
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
-  const handleClose = () => {
+  const handleClose = (type?: FieldTypes) => {
+    if (type) {
+      addField(type);
+    }
     setAnchorEl(null);
   };
 

--- a/app/src/features/ApplicationWorkspace/AddFieldButton.tsx
+++ b/app/src/features/ApplicationWorkspace/AddFieldButton.tsx
@@ -1,26 +1,47 @@
 import {Add} from '@mui/icons-material';
-import {Button, Tooltip} from '@mui/material';
+import {Button} from '@mui/material';
+import {useState} from 'react';
+
+import {Tooltip} from '../Common';
+import {AddFieldMenu} from './AddFieldMenu';
 
 export const AddFieldButton = () => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const isOpen = Boolean(anchorEl);
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
   return (
-    <Tooltip title="Add content field" placement="top">
-      <Button
-        variant="contained"
-        sx={{
-          backgroundColor: 'rgba(0, 0, 0, 1)',
-          borderRadius: '8px',
-          p: 1,
-          minWidth: 'auto',
-          color: 'palette.common.white',
-          '&:hover': {
-            backgroundColor: 'rgba(0, 0, 0, 0.8)',
-          },
-        }}
-        aria-label="Add Content"
-        size="small"
-      >
-        <Add sx={{height: '18px'}} />
-      </Button>
-    </Tooltip>
+    <>
+      <Tooltip title="Add content field" placement="top">
+        <Button
+          onClick={handleClick}
+          variant="contained"
+          sx={{
+            backgroundColor: 'rgba(0, 0, 0, 1)',
+            borderRadius: '8px',
+            p: 1,
+            minWidth: 'auto',
+            color: 'palette.common.white',
+            '&:hover': {
+              backgroundColor: 'rgba(0, 0, 0, 0.8)',
+            },
+          }}
+          aria-label="Add Content"
+          size="small"
+        >
+          <Add sx={{height: '18px'}} />
+        </Button>
+      </Tooltip>
+      <AddFieldMenu
+        isOpen={isOpen}
+        handleClose={handleClose}
+        anchorEl={anchorEl}
+      />
+    </>
   );
 };

--- a/app/src/features/ApplicationWorkspace/AddFieldMenu.tsx
+++ b/app/src/features/ApplicationWorkspace/AddFieldMenu.tsx
@@ -1,7 +1,8 @@
 import {Menu, MenuItem, MenuProps} from '@mui/material';
 import {alpha, styled} from '@mui/material/styles';
 
-import {FieldTypeOptions, FieldTypes} from './constants';
+import {FieldTypes} from './constants';
+import {FieldIcons} from './FieldIcons';
 
 interface Field {
   type: FieldTypes;
@@ -65,7 +66,7 @@ export const AddFieldMenu = ({
       {menuItems.map(({type, value}) => {
         return (
           <MenuItem key={type} onClick={() => handleClose(type)} disableRipple>
-            {FieldTypeOptions[type].icon}
+            {FieldIcons[type].icon}
             {value}
           </MenuItem>
         );

--- a/app/src/features/ApplicationWorkspace/AddFieldMenu.tsx
+++ b/app/src/features/ApplicationWorkspace/AddFieldMenu.tsx
@@ -9,7 +9,7 @@ interface Field {
   value: string;
 }
 
-const menuItems: Field[] = [
+export const menuItems: Field[] = [
   {
     type: 'short_text',
     value: 'Short text',

--- a/app/src/features/ApplicationWorkspace/AddFieldMenu.tsx
+++ b/app/src/features/ApplicationWorkspace/AddFieldMenu.tsx
@@ -1,64 +1,50 @@
-import {
-  Check,
-  Email,
-  ExpandMore,
-  LocalPhone,
-  RadioButtonChecked,
-  ShortText,
-  Subject,
-} from '@mui/icons-material';
 import {Menu, MenuItem, MenuProps} from '@mui/material';
 import {alpha, styled} from '@mui/material/styles';
 
-import {FieldTypes} from './constants';
+import {FieldTypeOptions, FieldTypes} from './constants';
 
 interface Field {
-  label: FieldTypes;
+  type: FieldTypes;
   value: string;
 }
 
 const menuItems: Field[] = [
   {
-    label: 'short_text',
+    type: 'short_text',
     value: 'Short text',
   },
   {
-    label: 'long_text',
+    type: 'long_text',
     value: 'Long text',
   },
   {
-    label: 'number',
+    type: 'number',
     value: 'Phone Number',
   },
 
   {
-    label: 'yes_no',
+    type: 'yes_no',
     value: 'Yes or No',
   },
   {
-    label: 'multiple_choice',
+    type: 'multiple_choice',
     value: 'Multiple Choice',
   },
 
   {
-    label: 'email',
+    type: 'email',
     value: 'Email',
   },
   {
-    label: 'dropdown',
+    type: 'dropdown',
     value: 'Dropdown',
   },
 ];
 
 interface AddFieldMenuProps {
   isOpen: boolean;
-  handleClose: () => void;
+  handleClose: (type?: FieldTypes) => void;
   anchorEl: HTMLElement | null;
-}
-
-interface FieldTypeOption {
-  icon: React.ReactNode;
-  color: string;
 }
 
 export const AddFieldMenu = ({
@@ -66,52 +52,20 @@ export const AddFieldMenu = ({
   handleClose,
   anchorEl,
 }: AddFieldMenuProps) => {
-  // object mapping field type to icon and color
-  const FieldTypeOptions: Record<FieldTypes, FieldTypeOption> = {
-    short_text: {
-      icon: <ShortText />,
-      color: 'primary.main',
-    },
-    long_text: {
-      icon: <Subject />,
-      color: 'secondary.main',
-    },
-    number: {
-      icon: <LocalPhone />,
-      color: 'warning.main',
-    },
-    yes_no: {
-      icon: <RadioButtonChecked />,
-      color: 'success.main',
-    },
-    multiple_choice: {
-      icon: <Check />,
-      color: 'success.main',
-    },
-    email: {
-      icon: <Email />,
-      color: 'error.main',
-    },
-    dropdown: {
-      icon: <ExpandMore />,
-      color: 'info.main',
-    },
-  };
-
   return (
     <StyledMenu
       open={isOpen}
-      onClose={handleClose}
+      onClose={() => handleClose()}
       anchorEl={anchorEl}
       id="add-field-menu"
       MenuListProps={{
         'aria-labelledby': 'add-field-menu',
       }}
     >
-      {menuItems.map(({label, value}) => {
+      {menuItems.map(({type, value}) => {
         return (
-          <MenuItem key={label} onClick={handleClose} disableRipple>
-            {FieldTypeOptions[label].icon}
+          <MenuItem key={type} onClick={() => handleClose(type)} disableRipple>
+            {FieldTypeOptions[type].icon}
             {value}
           </MenuItem>
         );

--- a/app/src/features/ApplicationWorkspace/AddFieldMenu.tsx
+++ b/app/src/features/ApplicationWorkspace/AddFieldMenu.tsx
@@ -1,0 +1,73 @@
+import {Menu, MenuItem, MenuProps} from '@mui/material';
+import {alpha, styled} from '@mui/material/styles';
+
+interface AddFieldMenuProps {
+  isOpen: boolean;
+  handleClose: () => void;
+  anchorEl: HTMLElement | null;
+}
+
+export const AddFieldMenu = ({
+  isOpen,
+  handleClose,
+  anchorEl,
+}: AddFieldMenuProps) => {
+  return (
+    <StyledMenu
+      open={isOpen}
+      onClose={handleClose}
+      anchorEl={anchorEl}
+      id="add-field-menu"
+      MenuListProps={{
+        'aria-labelledby': 'add-field-menu',
+      }}
+    >
+      <MenuItem onClick={handleClose} disableRipple>
+        Short Text
+      </MenuItem>
+    </StyledMenu>
+  );
+};
+
+const StyledMenu = styled((props: MenuProps) => (
+  <Menu
+    elevation={0}
+    anchorOrigin={{
+      vertical: 'top',
+      horizontal: 'right',
+    }}
+    transformOrigin={{
+      vertical: 'top',
+      horizontal: 'left',
+    }}
+    {...props}
+  />
+))(({theme}) => ({
+  '& .MuiPaper-root': {
+    borderRadius: 6,
+    marginLeft: theme.spacing(1),
+    minWidth: 180,
+    color:
+      theme.palette.mode === 'light'
+        ? 'rgb(55, 65, 81)'
+        : theme.palette.grey[300],
+    boxShadow:
+      'rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px',
+    '& .MuiMenu-list': {
+      padding: '4px 0',
+    },
+    '& .MuiMenuItem-root': {
+      '& .MuiSvgIcon-root': {
+        fontSize: 18,
+        color: theme.palette.text.secondary,
+        marginRight: theme.spacing(1.5),
+      },
+      '&:active': {
+        backgroundColor: alpha(
+          theme.palette.primary.main,
+          theme.palette.action.selectedOpacity
+        ),
+      },
+    },
+  },
+}));

--- a/app/src/features/ApplicationWorkspace/AddFieldMenu.tsx
+++ b/app/src/features/ApplicationWorkspace/AddFieldMenu.tsx
@@ -1,5 +1,54 @@
+import {
+  Check,
+  Email,
+  ExpandMore,
+  LocalPhone,
+  RadioButtonChecked,
+  ShortText,
+  Subject,
+} from '@mui/icons-material';
 import {Menu, MenuItem, MenuProps} from '@mui/material';
 import {alpha, styled} from '@mui/material/styles';
+
+import {FieldTypes} from './constants';
+
+interface Field {
+  label: FieldTypes;
+  value: string;
+}
+
+const menuItems: Field[] = [
+  {
+    label: 'short_text',
+    value: 'Short text',
+  },
+  {
+    label: 'long_text',
+    value: 'Long text',
+  },
+  {
+    label: 'number',
+    value: 'Phone Number',
+  },
+
+  {
+    label: 'yes_no',
+    value: 'Yes or No',
+  },
+  {
+    label: 'multiple_choice',
+    value: 'Multiple Choice',
+  },
+
+  {
+    label: 'email',
+    value: 'Email',
+  },
+  {
+    label: 'dropdown',
+    value: 'Dropdown',
+  },
+];
 
 interface AddFieldMenuProps {
   isOpen: boolean;
@@ -7,11 +56,48 @@ interface AddFieldMenuProps {
   anchorEl: HTMLElement | null;
 }
 
+interface FieldTypeOption {
+  icon: React.ReactNode;
+  color: string;
+}
+
 export const AddFieldMenu = ({
   isOpen,
   handleClose,
   anchorEl,
 }: AddFieldMenuProps) => {
+  // object mapping field type to icon and color
+  const FieldTypeOptions: Record<FieldTypes, FieldTypeOption> = {
+    short_text: {
+      icon: <ShortText />,
+      color: 'primary.main',
+    },
+    long_text: {
+      icon: <Subject />,
+      color: 'secondary.main',
+    },
+    number: {
+      icon: <LocalPhone />,
+      color: 'warning.main',
+    },
+    yes_no: {
+      icon: <RadioButtonChecked />,
+      color: 'success.main',
+    },
+    multiple_choice: {
+      icon: <Check />,
+      color: 'success.main',
+    },
+    email: {
+      icon: <Email />,
+      color: 'error.main',
+    },
+    dropdown: {
+      icon: <ExpandMore />,
+      color: 'info.main',
+    },
+  };
+
   return (
     <StyledMenu
       open={isOpen}
@@ -22,9 +108,14 @@ export const AddFieldMenu = ({
         'aria-labelledby': 'add-field-menu',
       }}
     >
-      <MenuItem onClick={handleClose} disableRipple>
-        Short Text
-      </MenuItem>
+      {menuItems.map(({label, value}) => {
+        return (
+          <MenuItem key={label} onClick={handleClose} disableRipple>
+            {FieldTypeOptions[label].icon}
+            {value}
+          </MenuItem>
+        );
+      })}
     </StyledMenu>
   );
 };
@@ -44,7 +135,7 @@ const StyledMenu = styled((props: MenuProps) => (
   />
 ))(({theme}) => ({
   '& .MuiPaper-root': {
-    borderRadius: 6,
+    borderRadius: 8,
     marginLeft: theme.spacing(1),
     minWidth: 180,
     color:
@@ -54,13 +145,14 @@ const StyledMenu = styled((props: MenuProps) => (
     boxShadow:
       'rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px',
     '& .MuiMenu-list': {
-      padding: '4px 0',
+      padding: '4px 4px',
     },
     '& .MuiMenuItem-root': {
+      borderRadius: 4,
       '& .MuiSvgIcon-root': {
-        fontSize: 18,
-        color: theme.palette.text.secondary,
         marginRight: theme.spacing(1.5),
+        fontSize: 18,
+        color: theme.palette.text.primary,
       },
       '&:active': {
         backgroundColor: alpha(

--- a/app/src/features/ApplicationWorkspace/FieldIcons.tsx
+++ b/app/src/features/ApplicationWorkspace/FieldIcons.tsx
@@ -1,0 +1,47 @@
+import {
+  Check,
+  Email,
+  ExpandMore,
+  LocalPhone,
+  RadioButtonChecked,
+  ShortText,
+  Subject,
+} from '@mui/icons-material';
+
+import {FieldTypes} from './constants';
+
+interface FieldTypeOption {
+  icon: React.ReactNode;
+  color: string;
+}
+
+export const FieldIcons: Record<FieldTypes, FieldTypeOption> = {
+  short_text: {
+    icon: <ShortText />,
+    color: 'primary.main',
+  },
+  long_text: {
+    icon: <Subject />,
+    color: 'secondary.main',
+  },
+  number: {
+    icon: <LocalPhone />,
+    color: 'warning.main',
+  },
+  yes_no: {
+    icon: <RadioButtonChecked />,
+    color: 'success.main',
+  },
+  multiple_choice: {
+    icon: <Check />,
+    color: 'success.main',
+  },
+  email: {
+    icon: <Email />,
+    color: 'error.main',
+  },
+  dropdown: {
+    icon: <ExpandMore />,
+    color: 'info.main',
+  },
+};

--- a/app/src/features/ApplicationWorkspace/FieldList.tsx
+++ b/app/src/features/ApplicationWorkspace/FieldList.tsx
@@ -1,0 +1,36 @@
+import {List, ListItemButton, ListItemIcon, ListItemText} from '@mui/material';
+import {MouseEvent as ReactMouseEvent} from 'react';
+
+import {Field, FieldTypeOptions} from './constants';
+
+interface FieldListProps {
+  fields: Field[];
+  handleListItemClick: (
+    event: ReactMouseEvent<HTMLDivElement, MouseEvent>,
+    id: string
+  ) => void;
+  selectedId: string | null;
+}
+
+export const FieldList = ({
+  fields,
+  selectedId,
+  handleListItemClick,
+}: FieldListProps) => {
+  return (
+    <List aria-label="list of fields">
+      {fields.map(({id, type, title}) => (
+        <ListItemButton
+          key={id}
+          selected={selectedId === id}
+          onClick={event => handleListItemClick(event, id)}
+        >
+          <ListItemIcon sx={{color: 'text.primary'}}>
+            {FieldTypeOptions[type].icon}
+          </ListItemIcon>
+          <ListItemText primary={title} />
+        </ListItemButton>
+      ))}
+    </List>
+  );
+};

--- a/app/src/features/ApplicationWorkspace/FieldList.tsx
+++ b/app/src/features/ApplicationWorkspace/FieldList.tsx
@@ -1,7 +1,8 @@
 import {List, ListItemButton, ListItemIcon, ListItemText} from '@mui/material';
 import {MouseEvent as ReactMouseEvent} from 'react';
 
-import {Field, FieldTypeOptions} from './constants';
+import {Field} from './constants';
+import {FieldIcons} from './FieldIcons';
 
 interface FieldListProps {
   fields: Field[];
@@ -18,15 +19,17 @@ export const FieldList = ({
   handleListItemClick,
 }: FieldListProps) => {
   return (
-    <List aria-label="list of fields">
+    <List sx={{px: 1}} aria-label="list of fields">
       {fields.map(({id, type, title}) => (
         <ListItemButton
+          sx={{borderRadius: '8px'}}
           key={id}
           selected={selectedId === id}
           onClick={event => handleListItemClick(event, id)}
+          disableRipple
         >
           <ListItemIcon sx={{color: 'text.primary'}}>
-            {FieldTypeOptions[type].icon}
+            {FieldIcons[type].icon}
           </ListItemIcon>
           <ListItemText primary={title} />
         </ListItemButton>

--- a/app/src/features/ApplicationWorkspace/FieldList.tsx
+++ b/app/src/features/ApplicationWorkspace/FieldList.tsx
@@ -1,4 +1,10 @@
-import {List, ListItemButton, ListItemIcon, ListItemText} from '@mui/material';
+import {
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+} from '@mui/material';
 import {MouseEvent as ReactMouseEvent} from 'react';
 
 import {Field} from './constants';
@@ -21,18 +27,20 @@ export const FieldList = ({
   return (
     <List sx={{px: 1}} aria-label="list of fields">
       {fields.map(({id, type, title}) => (
-        <ListItemButton
-          sx={{borderRadius: '8px'}}
-          key={id}
-          selected={selectedId === id}
-          onClick={event => handleListItemClick(event, id)}
-          disableRipple
-        >
-          <ListItemIcon sx={{color: 'text.primary'}}>
-            {FieldIcons[type].icon}
-          </ListItemIcon>
-          <ListItemText primary={title} />
-        </ListItemButton>
+        <ListItem key={id} disableGutters disablePadding>
+          <ListItemButton
+            sx={{borderRadius: '8px'}}
+            aria-selected={selectedId === id}
+            selected={selectedId === id}
+            onClick={event => handleListItemClick(event, id)}
+            disableRipple
+          >
+            <ListItemIcon sx={{color: 'text.primary'}}>
+              {FieldIcons[type].icon}
+            </ListItemIcon>
+            <ListItemText primary={title} />
+          </ListItemButton>
+        </ListItem>
       ))}
     </List>
   );

--- a/app/src/features/ApplicationWorkspace/LeftPanel.tsx
+++ b/app/src/features/ApplicationWorkspace/LeftPanel.tsx
@@ -14,7 +14,7 @@ export const LeftPanel = () => {
   const selectedId = useAppSelector(state => state.workspace.selectedId);
   const dispatch = useAppDispatch();
 
-  const handleListItemClick = (
+  const selectFieldById = (
     event: ReactMouseEvent<HTMLDivElement, MouseEvent>,
     id: string
   ) => {
@@ -47,7 +47,7 @@ export const LeftPanel = () => {
       </Stack>
       <FieldList
         fields={fields}
-        handleListItemClick={handleListItemClick}
+        handleListItemClick={selectFieldById}
         selectedId={selectedId}
       />
     </PanelContainer>

--- a/app/src/features/ApplicationWorkspace/LeftPanel.tsx
+++ b/app/src/features/ApplicationWorkspace/LeftPanel.tsx
@@ -1,7 +1,6 @@
-import {Add} from '@mui/icons-material';
-import {Button, Stack, Typography} from '@mui/material';
+import {Stack, Typography} from '@mui/material';
 
-import {Tooltip} from '../Common';
+import {AddFieldButton} from './AddFieldButton';
 import {PanelContainer} from './PanelContainer';
 
 export const LeftPanel = () => {
@@ -16,25 +15,7 @@ export const LeftPanel = () => {
         <Typography variant="subtitle1" fontWeight="500">
           Content
         </Typography>
-        <Tooltip title="Add content field" placement="top">
-          <Button
-            variant="contained"
-            sx={{
-              backgroundColor: 'rgba(0, 0, 0, 1)',
-              borderRadius: '8px',
-              p: 1,
-              minWidth: 'auto',
-              color: 'palette.common.white',
-              '&:hover': {
-                backgroundColor: 'rgba(0, 0, 0, 0.8)',
-              },
-            }}
-            aria-label="Add Content"
-            size="small"
-          >
-            <Add sx={{height: '18px'}} />
-          </Button>
-        </Tooltip>
+        <AddFieldButton />
       </Stack>
     </PanelContainer>
   );

--- a/app/src/features/ApplicationWorkspace/LeftPanel.tsx
+++ b/app/src/features/ApplicationWorkspace/LeftPanel.tsx
@@ -1,9 +1,35 @@
+import {faker} from '@faker-js/faker';
 import {Stack, Typography} from '@mui/material';
+import {MouseEvent as ReactMouseEvent, useState} from 'react';
 
 import {AddFieldButton} from './AddFieldButton';
+import {Field, FieldTypes} from './constants';
+import {FieldList} from './FieldList';
 import {PanelContainer} from './PanelContainer';
 
 export const LeftPanel = () => {
+  const [fields, setFields] = useState<Field[]>([]);
+  const [selectedId, setSelectedId] = useState<null | string>(null);
+
+  const handleListItemClick = (
+    event: ReactMouseEvent<HTMLDivElement, MouseEvent>,
+    id: string
+  ) => {
+    setSelectedId(id);
+  };
+
+  const addField = (fieldType: FieldTypes) => {
+    const newField = {
+      id: faker.string.uuid(),
+      type: fieldType,
+      title: '...',
+    };
+
+    setFields(prevFields => [...prevFields, newField]);
+
+    setSelectedId(newField.id);
+  };
+
   return (
     <PanelContainer side="left">
       <Stack
@@ -15,8 +41,13 @@ export const LeftPanel = () => {
         <Typography variant="subtitle1" fontWeight="500">
           Content
         </Typography>
-        <AddFieldButton />
+        <AddFieldButton addField={addField} />
       </Stack>
+      <FieldList
+        fields={fields}
+        handleListItemClick={handleListItemClick}
+        selectedId={selectedId}
+      />
     </PanelContainer>
   );
 };

--- a/app/src/features/ApplicationWorkspace/LeftPanel.tsx
+++ b/app/src/features/ApplicationWorkspace/LeftPanel.tsx
@@ -1,33 +1,35 @@
 import {faker} from '@faker-js/faker';
 import {Stack, Typography} from '@mui/material';
-import {MouseEvent as ReactMouseEvent, useState} from 'react';
+import {MouseEvent as ReactMouseEvent} from 'react';
 
+import {useAppDispatch, useAppSelector} from '../../redux/hooks';
 import {AddFieldButton} from './AddFieldButton';
-import {Field, FieldTypes} from './constants';
+import {FieldTypes} from './constants';
 import {FieldList} from './FieldList';
 import {PanelContainer} from './PanelContainer';
+import {addField, Field, setSelectedId} from './workspaceSlice';
 
 export const LeftPanel = () => {
-  const [fields, setFields] = useState<Field[]>([]);
-  const [selectedId, setSelectedId] = useState<null | string>(null);
+  const fields = useAppSelector(state => state.workspace.fields);
+  const selectedId = useAppSelector(state => state.workspace.selectedId);
+  const dispatch = useAppDispatch();
 
   const handleListItemClick = (
     event: ReactMouseEvent<HTMLDivElement, MouseEvent>,
     id: string
   ) => {
-    setSelectedId(id);
+    dispatch(setSelectedId(id));
   };
 
-  const addField = (fieldType: FieldTypes) => {
-    const newField = {
+  const addFields = (fieldType: FieldTypes) => {
+    const newField: Field = {
       id: faker.string.uuid(),
       type: fieldType,
       title: '...',
     };
 
-    setFields(prevFields => [...prevFields, newField]);
-
-    setSelectedId(newField.id);
+    dispatch(addField(newField));
+    dispatch(setSelectedId(newField.id));
   };
 
   return (
@@ -41,7 +43,7 @@ export const LeftPanel = () => {
         <Typography variant="subtitle1" fontWeight="500">
           Content
         </Typography>
-        <AddFieldButton addField={addField} />
+        <AddFieldButton addField={addFields} />
       </Stack>
       <FieldList
         fields={fields}

--- a/app/src/features/ApplicationWorkspace/__tests__/AddFieldButton.test.tsx
+++ b/app/src/features/ApplicationWorkspace/__tests__/AddFieldButton.test.tsx
@@ -1,0 +1,45 @@
+import {render, screen, userEvent} from '../../../utils/test/test-utils';
+import {AddFieldButton} from '../AddFieldButton';
+
+describe('AddFieldButton', () => {
+  test('renders button with icon and tooltip', () => {
+    render(<AddFieldButton addField={vi.fn()} />);
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByTestId('AddIcon')).toBeInTheDocument();
+  });
+
+  test('toggles menu when button is clicked', async () => {
+    render(<AddFieldButton addField={vi.fn()} />);
+
+    const addFieldButton = screen.getByRole('button', {name: /add content/i});
+    await userEvent.click(addFieldButton);
+    await screen.findByRole('menu');
+    await userEvent.click(
+      screen.getByRole('presentation').firstChild as HTMLElement
+    );
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  test('calls addField with the correct type when menu item is clicked', async () => {
+    const addField = vi.fn();
+    render(<AddFieldButton addField={addField} />);
+
+    const addFieldButton = screen.getByRole('button', {name: /add content/i});
+    await userEvent.click(addFieldButton);
+    await screen.findByRole('menu');
+    const menuItem = screen.getByRole('menuitem', {name: /short text/i});
+    await userEvent.click(menuItem);
+    expect(addField).toHaveBeenCalledWith('short_text');
+  });
+
+  test('closes menu when menu item is clicked', async () => {
+    render(<AddFieldButton addField={vi.fn()} />);
+
+    const addFieldButton = screen.getByRole('button', {name: /add content/i});
+    await userEvent.click(addFieldButton);
+    const menuItem = await screen.findByRole('menuitem', {name: /short text/i});
+    await userEvent.click(menuItem);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+});

--- a/app/src/features/ApplicationWorkspace/__tests__/LeftPanel.test.tsx
+++ b/app/src/features/ApplicationWorkspace/__tests__/LeftPanel.test.tsx
@@ -1,0 +1,69 @@
+import {RootState} from '../../../redux/store';
+import {
+  render,
+  screen,
+  userEvent,
+  within,
+} from '../../../utils/test/test-utils';
+import {fieldBuilder} from '../constants';
+import {LeftPanel} from '../LeftPanel';
+
+const setup = (preloadedState: Partial<RootState> = {}) => {
+  render(<LeftPanel />, {
+    preloadedState: {
+      workspace: {fields: [], selectedId: null},
+      ...preloadedState,
+    },
+  });
+
+  const addButton = screen.getByRole('button', {name: /add content/i});
+  const fieldList = screen.getByRole('list', {name: /list of fields/i});
+
+  return {
+    addButton,
+    fieldList,
+  };
+};
+
+describe('LeftPanel', () => {
+  test('Selecting a field from the menu adds a new field to the list', async () => {
+    const {addButton} = setup();
+
+    await userEvent.click(addButton);
+    const shortTextItem = await screen.findByRole('menuitem', {
+      name: /short text/i,
+    });
+
+    await userEvent.click(shortTextItem);
+    const fields = await screen.findAllByRole('listitem');
+
+    expect(fields).toHaveLength(1);
+    expect(fields[0]).toHaveTextContent(/.../i);
+    expect(within(fields[0]).getByRole('button')).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+
+  test('clicking on list item selects it', async () => {
+    const fields = Array.from(Array(3), () => fieldBuilder());
+    setup({workspace: {fields, selectedId: fields[0].id}});
+
+    const listItems = await screen.findAllByRole('listitem');
+    expect(listItems).toHaveLength(fields.length);
+    expect(within(listItems[0]).getByRole('button')).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+
+    await userEvent.click(within(listItems[1]).getByRole('button'));
+    expect(within(listItems[0]).getByRole('button')).toHaveAttribute(
+      'aria-selected',
+      'false'
+    );
+    expect(within(listItems[1]).getByRole('button')).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+});

--- a/app/src/features/ApplicationWorkspace/constants.ts
+++ b/app/src/features/ApplicationWorkspace/constants.ts
@@ -1,17 +1,30 @@
-export type FieldTypes =
-  | 'short_text'
-  | 'long_text'
-  | 'number'
-  | 'email'
-  | 'dropdown'
-  | 'multiple_choice'
-  | 'yes_no';
+import {faker} from '@faker-js/faker';
+
+const fieldTypes = [
+  'short_text',
+  'long_text',
+  'number',
+  'email',
+  'dropdown',
+  'multiple_choice',
+  'yes_no',
+] as const;
+
+type FieldTypeTuple = typeof fieldTypes;
+
+export type FieldTypes = FieldTypeTuple[number];
 
 export interface Field {
   id: string;
   title: string;
   type: FieldTypes;
 }
+
+export const fieldBuilder = () => ({
+  id: faker.string.numeric(4),
+  title: faker.lorem.sentence(),
+  type: faker.helpers.arrayElement(fieldTypes),
+});
 
 // interface BaseProperties {
 //   description?: string;

--- a/app/src/features/ApplicationWorkspace/constants.ts
+++ b/app/src/features/ApplicationWorkspace/constants.ts
@@ -1,4 +1,4 @@
-type FieldTypes =
+export type FieldTypes =
   | 'short_text'
   | 'long_text'
   | 'number'

--- a/app/src/features/ApplicationWorkspace/constants.ts
+++ b/app/src/features/ApplicationWorkspace/constants.ts
@@ -1,13 +1,3 @@
-import {
-  Check,
-  Email,
-  ExpandMore,
-  LocalPhone,
-  RadioButtonChecked,
-  ShortText,
-  Subject,
-} from '@mui/icons-material';
-
 export type FieldTypes =
   | 'short_text'
   | 'long_text'
@@ -150,40 +140,4 @@ export const fields = {
       type: 'yes_no',
     },
   ],
-};
-
-interface FieldTypeOption {
-  icon: React.ReactNode;
-  color: string;
-}
-
-export const FieldTypeOptions: Record<FieldTypes, FieldTypeOption> = {
-  short_text: {
-    icon: <ShortText />,
-    color: 'primary.main',
-  },
-  long_text: {
-    icon: <Subject />,
-    color: 'secondary.main',
-  },
-  number: {
-    icon: <LocalPhone />,
-    color: 'warning.main',
-  },
-  yes_no: {
-    icon: <RadioButtonChecked />,
-    color: 'success.main',
-  },
-  multiple_choice: {
-    icon: <Check />,
-    color: 'success.main',
-  },
-  email: {
-    icon: <Email />,
-    color: 'error.main',
-  },
-  dropdown: {
-    icon: <ExpandMore />,
-    color: 'info.main',
-  },
 };

--- a/app/src/features/ApplicationWorkspace/constants.tsx
+++ b/app/src/features/ApplicationWorkspace/constants.tsx
@@ -1,3 +1,13 @@
+import {
+  Check,
+  Email,
+  ExpandMore,
+  LocalPhone,
+  RadioButtonChecked,
+  ShortText,
+  Subject,
+} from '@mui/icons-material';
+
 export type FieldTypes =
   | 'short_text'
   | 'long_text'
@@ -7,28 +17,34 @@ export type FieldTypes =
   | 'multiple_choice'
   | 'yes_no';
 
-interface BaseProperties {
-  description?: string;
-}
-
-interface BaseValidations {
-  required: boolean;
-}
-
-interface BaseField {
+export interface Field {
   id: string;
   title: string;
   type: FieldTypes;
-  properties: BaseProperties;
-  validations: BaseValidations;
 }
 
-export interface ShortTextField extends BaseField {
-  validations: {
-    required: boolean;
-    max_length?: number;
-  };
-}
+// interface BaseProperties {
+//   description?: string;
+// }
+
+// interface BaseValidations {
+//   required: boolean;
+// }
+
+// interface BaseField {
+//   id: string;
+//   title: string;
+//   type: FieldTypes;
+//   properties: BaseProperties;
+//   validations: BaseValidations;
+// }
+
+// export interface ShortTextField extends BaseField {
+//   validations: {
+//     required: boolean;
+//     max_length?: number;
+//   };
+// }
 
 export const fields = {
   fields: [
@@ -134,4 +150,40 @@ export const fields = {
       type: 'yes_no',
     },
   ],
+};
+
+interface FieldTypeOption {
+  icon: React.ReactNode;
+  color: string;
+}
+
+export const FieldTypeOptions: Record<FieldTypes, FieldTypeOption> = {
+  short_text: {
+    icon: <ShortText />,
+    color: 'primary.main',
+  },
+  long_text: {
+    icon: <Subject />,
+    color: 'secondary.main',
+  },
+  number: {
+    icon: <LocalPhone />,
+    color: 'warning.main',
+  },
+  yes_no: {
+    icon: <RadioButtonChecked />,
+    color: 'success.main',
+  },
+  multiple_choice: {
+    icon: <Check />,
+    color: 'success.main',
+  },
+  email: {
+    icon: <Email />,
+    color: 'error.main',
+  },
+  dropdown: {
+    icon: <ExpandMore />,
+    color: 'info.main',
+  },
 };

--- a/app/src/features/ApplicationWorkspace/workspaceSlice.ts
+++ b/app/src/features/ApplicationWorkspace/workspaceSlice.ts
@@ -1,0 +1,43 @@
+import {createSlice, PayloadAction} from '@reduxjs/toolkit';
+
+export type FieldTypes =
+  | 'short_text'
+  | 'long_text'
+  | 'number'
+  | 'email'
+  | 'dropdown'
+  | 'multiple_choice'
+  | 'yes_no';
+
+export interface Field {
+  id: string;
+  title: string;
+  type: FieldTypes;
+}
+
+interface WorkspaceState {
+  selectedId: string | null;
+  fields: Field[];
+}
+
+const initialState: WorkspaceState = {
+  selectedId: null,
+  fields: [],
+};
+
+const workspaceSlice = createSlice({
+  name: 'workspace',
+  initialState,
+  reducers: {
+    setSelectedId: (state, action) => {
+      state.selectedId = action.payload;
+    },
+    addField: (state, action: PayloadAction<Field>) => {
+      state.fields.push(action.payload);
+    },
+  },
+});
+
+const {actions, reducer} = workspaceSlice;
+export const {setSelectedId, addField} = actions;
+export default reducer;

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -7,11 +7,9 @@ import ReactDOM from 'react-dom/client';
 import {Provider} from 'react-redux';
 import {createBrowserRouter, RouterProvider} from 'react-router-dom';
 
-import {setupStore} from './redux/store.ts';
+import {store} from './redux/store.ts';
 import theme from './utils/theme.tsx';
 import {App, ApplicationWorkspace} from './views';
-
-const store = setupStore();
 
 export const router = createBrowserRouter([
   {

--- a/app/src/redux/store.ts
+++ b/app/src/redux/store.ts
@@ -1,16 +1,22 @@
-import {configureStore, ConfigureStoreOptions} from '@reduxjs/toolkit';
+import {
+  combineReducers,
+  configureStore,
+  ConfigureStoreOptions,
+} from '@reduxjs/toolkit';
 
 import workspace from '../features/ApplicationWorkspace/workspaceSlice';
 import {emptySplitApi} from '../services/emptyApi';
+
+const rootReducer = combineReducers({
+  [emptySplitApi.reducerPath]: emptySplitApi.reducer,
+  workspace,
+});
 
 export const setupStore = (
   options?: ConfigureStoreOptions['preloadedState'] | undefined
 ) => {
   return configureStore({
-    reducer: {
-      [emptySplitApi.reducerPath]: emptySplitApi.reducer,
-      workspace,
-    },
+    reducer: rootReducer,
     middleware: getDefaultMiddleware =>
       getDefaultMiddleware().concat(emptySplitApi.middleware),
     devTools: process.env.NODE_ENV !== 'production',
@@ -20,6 +26,6 @@ export const setupStore = (
 
 export const store = setupStore();
 
-export type RootState = ReturnType<typeof store.getState>;
+export type RootState = ReturnType<typeof rootReducer>;
 export type AppStore = ReturnType<typeof setupStore>;
 export type AppDispatch = AppStore['dispatch'];

--- a/app/src/redux/store.ts
+++ b/app/src/redux/store.ts
@@ -1,21 +1,25 @@
-import {combineReducers, configureStore} from '@reduxjs/toolkit';
+import {configureStore, ConfigureStoreOptions} from '@reduxjs/toolkit';
 
+import workspace from '../features/ApplicationWorkspace/workspaceSlice';
 import {emptySplitApi} from '../services/emptyApi';
 
-const rootReducer = combineReducers({
-  [emptySplitApi.reducerPath]: emptySplitApi.reducer,
-});
-
-export const setupStore = (preloadedState?: Partial<RootState>) => {
+export const setupStore = (
+  options?: ConfigureStoreOptions['preloadedState'] | undefined
+) => {
   return configureStore({
-    reducer: rootReducer,
-    preloadedState,
+    reducer: {
+      [emptySplitApi.reducerPath]: emptySplitApi.reducer,
+      workspace,
+    },
     middleware: getDefaultMiddleware =>
       getDefaultMiddleware().concat(emptySplitApi.middleware),
     devTools: process.env.NODE_ENV !== 'production',
+    ...options,
   });
 };
 
-export type RootState = ReturnType<typeof rootReducer>;
+export const store = setupStore();
+
+export type RootState = ReturnType<typeof store.getState>;
 export type AppStore = ReturnType<typeof setupStore>;
 export type AppDispatch = AppStore['dispatch'];

--- a/app/src/services/emptyApi.ts
+++ b/app/src/services/emptyApi.ts
@@ -3,6 +3,7 @@ import {createApi, fetchBaseQuery} from '@reduxjs/toolkit/query/react';
 
 // initialize an empty api service that we'll inject endpoints into later as needed
 export const emptySplitApi = createApi({
+  reducerPath: 'emptySplitApi',
   baseQuery: fetchBaseQuery({
     baseUrl: `${import.meta.env.VITE_API_BASE_URL}/api`,
   }),

--- a/app/src/utils/test/test-utils.tsx
+++ b/app/src/utils/test/test-utils.tsx
@@ -21,7 +21,7 @@ const customRender = (
   {
     preloadedState = {},
     // Automatically create a store instance if no store was passed in
-    store = setupStore(preloadedState),
+    store = setupStore({preloadedState}),
     ...renderOptions
   }: ExtendedRenderOptions = {}
 ) => {


### PR DESCRIPTION
This PR includes the following changes:

- Create a popup menu component that lists the available fields
- Open popup menu when clicking the add field button
- Adds the selected field to the side bar and makes it the selected item
- Highlights the selected item
- Writes tests

https://github.com/erikguntner/form-generator/assets/27253583/22851ac0-4d37-4750-8322-74a94c0386a7

