### PR TITLE
Render selected field

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/material": "^5.14.18",
         "@reduxjs/toolkit": "^2.0.1",
         "react": "^18.2.0",
+        "react-contenteditable": "^3.3.7",
         "react-dom": "^18.2.0",
         "react-redux": "^9.0.2",
         "react-router-dom": "^6.20.1"
@@ -4098,8 +4099,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -6668,6 +6668,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-contenteditable": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/react-contenteditable/-/react-contenteditable-3.3.7.tgz",
+      "integrity": "sha512-GA9NbC0DkDdpN3iGvib/OMHWTJzDX2cfkgy5Tt98JJAbA3kLnyrNbBIpsSpPpq7T8d3scD39DHP+j8mAM7BIfQ==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "prop-types": "^15.7.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.3"
       }
     },
     "node_modules/react-dom": {

--- a/app/package.json
+++ b/app/package.json
@@ -19,6 +19,7 @@
     "@mui/material": "^5.14.18",
     "@reduxjs/toolkit": "^2.0.1",
     "react": "^18.2.0",
+    "react-contenteditable": "^3.3.7",
     "react-dom": "^18.2.0",
     "react-redux": "^9.0.2",
     "react-router-dom": "^6.20.1"

--- a/app/src/features/ApplicationWorkspace/ApplicationFields/EmailField.tsx
+++ b/app/src/features/ApplicationWorkspace/ApplicationFields/EmailField.tsx
@@ -1,0 +1,14 @@
+import {TextField, TextFieldProps} from '@mui/material';
+
+interface EmailFieldProps {}
+
+export const EmailField = ({...props}: EmailFieldProps & TextFieldProps) => {
+  return (
+    <TextField
+      id="outlined"
+      placeholder="example@emai.com"
+      variant="outlined"
+      {...props}
+    />
+  );
+};

--- a/app/src/features/ApplicationWorkspace/ApplicationFields/LongTextField.tsx
+++ b/app/src/features/ApplicationWorkspace/ApplicationFields/LongTextField.tsx
@@ -1,0 +1,20 @@
+import {TextField, TextFieldProps} from '@mui/material';
+
+interface LongTextFieldProps {
+  props?: TextFieldProps;
+}
+
+export const LongTextField = ({
+  ...props
+}: LongTextFieldProps & TextFieldProps) => {
+  return (
+    <TextField
+      multiline
+      rows={4}
+      id="outlined"
+      placeholder="Type you answer here"
+      variant="outlined"
+      {...props}
+    />
+  );
+};

--- a/app/src/features/ApplicationWorkspace/ApplicationFields/PhoneNumberField.tsx
+++ b/app/src/features/ApplicationWorkspace/ApplicationFields/PhoneNumberField.tsx
@@ -1,0 +1,16 @@
+import {TextField, TextFieldProps} from '@mui/material';
+
+interface PhoneNumberFieldProps {}
+
+export const PhoneNumberField = ({
+  ...props
+}: PhoneNumberFieldProps & TextFieldProps) => {
+  return (
+    <TextField
+      id="outlined"
+      placeholder="(909)555-1234"
+      variant="outlined"
+      {...props}
+    />
+  );
+};

--- a/app/src/features/ApplicationWorkspace/ApplicationFields/ShortTextField.tsx
+++ b/app/src/features/ApplicationWorkspace/ApplicationFields/ShortTextField.tsx
@@ -1,0 +1,18 @@
+import {TextField, TextFieldProps} from '@mui/material';
+
+interface ShortTextFieldProps {}
+
+export const ShortTextField = ({
+  ...props
+}: ShortTextFieldProps & TextFieldProps) => {
+  return (
+    <TextField
+      multiline
+      rows={2}
+      id="outlined"
+      variant="outlined"
+      placeholder="Type you answer here"
+      {...props}
+    />
+  );
+};

--- a/app/src/features/ApplicationWorkspace/ApplicationFields/index.tsx
+++ b/app/src/features/ApplicationWorkspace/ApplicationFields/index.tsx
@@ -1,0 +1,4 @@
+export {EmailField} from './EmailField';
+export {LongTextField} from './LongTextField';
+export {PhoneNumberField} from './PhoneNumberField';
+export {ShortTextField} from './ShortTextField';

--- a/app/src/features/ApplicationWorkspace/CenterWindow.tsx
+++ b/app/src/features/ApplicationWorkspace/CenterWindow.tsx
@@ -1,18 +1,97 @@
-import {Stack} from '@mui/material';
+import {Stack, styled, Typography} from '@mui/material';
+import ContentEdidable from 'react-contenteditable';
+
+import {useAppDispatch, useAppSelector} from '../../redux/hooks';
+import {editField, Field} from './workspaceSlice';
+
 export const CenterWindow = () => {
+  const dispatch = useAppDispatch();
+  const selectedField = useAppSelector(({workspace}) =>
+    workspace.fields.find(field => field.id === workspace.selectedId)
+  );
+
+  const handleOnInput = (options: Partial<Field>) => {
+    dispatch(
+      editField({
+        id: selectedField?.id,
+        ...options,
+      })
+    );
+  };
+
   return (
     <Stack sx={{flex: 1, py: 10, px: 2}}>
-      <Stack
-        sx={{
-          height: '100%',
-          width: '100%',
-          aspectRatio: 'auto',
-          backgroundColor: 'background.default',
-          borderRadius: 2,
-          boxShadow:
-            'rgba(0, 0, 0, 0.08) 0px 2px 4px, rgba(0, 0, 0, 0.06) 0px 2px 12px;',
-        }}
-      ></Stack>
+      <StyledWindow>
+        {selectedField === undefined ? (
+          <Stack
+            sx={{
+              justifyContent: 'center',
+              alignItems: 'center',
+              flex: 1,
+              height: '100%',
+            }}
+          >
+            <Typography variant="h5" sx={{color: 'text.secondary'}}>
+              Select a field
+            </Typography>
+          </Stack>
+        ) : (
+          <Stack>
+            <Typography variant="h5">
+              <StyledContentEditable
+                onChange={event =>
+                  handleOnInput({title: event.currentTarget.textContent})
+                }
+                contentEditable
+                data-placeholder="Write your question here"
+                suppressContentEditableWarning
+                html={selectedField.title}
+              />
+            </Typography>
+            {/* <Typography variant="body1">
+              <StyledContentEditable
+                onChange={event =>
+                  handleOnInput({
+                    description: event.currentTarget.textContent,
+                  })
+                }
+                contentEditable
+                data-placeholder="Write a desecription (optional)"
+                suppressContentEditableWarning
+                html={selectedField.title}
+              />
+            </Typography> */}
+
+            {/* <StyledEditableText
+              onInput={handleOnInput}
+              contentEditable
+              variant="h5"
+              data-placeholder="Write your question here"
+              suppressContentEditableWarning
+            >
+              {selectedField.title}
+            </StyledEditableText> */}
+          </Stack>
+        )}
+      </StyledWindow>
     </Stack>
   );
 };
+
+const StyledWindow = styled(Stack)(({theme}) => ({
+  height: '100%',
+  width: '100%',
+  aspectRatio: 'auto',
+  backgroundColor: theme.palette.background.default,
+  borderRadius: 2,
+  boxShadow:
+    'rgba(0, 0, 0, 0.08) 0px 2px 4px, rgba(0, 0, 0, 0.06) 0px 2px 12px;',
+}));
+
+const StyledContentEditable = styled(ContentEdidable)(({theme}) => ({
+  '&[contenteditable="true"]:empty:before': {
+    content: 'attr(data-placeholder)',
+    display: 'block',
+    color: theme.palette.text.secondary,
+  },
+}));

--- a/app/src/features/ApplicationWorkspace/CenterWindow.tsx
+++ b/app/src/features/ApplicationWorkspace/CenterWindow.tsx
@@ -3,7 +3,7 @@ import ContentEdidable from 'react-contenteditable';
 
 import {useAppDispatch, useAppSelector} from '../../redux/hooks';
 import {RenderFields} from './RenderApplicationFields';
-import {editField, Field} from './workspaceSlice';
+import {editField, Fields} from './workspaceSlice';
 
 export const CenterWindow = () => {
   const dispatch = useAppDispatch();
@@ -11,7 +11,7 @@ export const CenterWindow = () => {
     workspace.fields.find(field => field.id === workspace.selectedId)
   );
 
-  const handleOnChange = (options: Partial<Field>) => {
+  const handleOnChange = (options: Partial<Fields>) => {
     dispatch(
       editField({
         id: selectedField?.id,
@@ -19,6 +19,8 @@ export const CenterWindow = () => {
       })
     );
   };
+
+  console.log(selectedField?.properties.description);
 
   return (
     <Stack sx={{flex: 1, py: 10, px: 2}}>
@@ -40,7 +42,7 @@ export const CenterWindow = () => {
           <Container sx={{height: '100%'}} maxWidth="sm">
             <Stack sx={{height: '100%'}} justifyContent={'center'} gap={3}>
               <Stack>
-                <Typography variant="h5">
+                <Typography aria-labelledby="editable-title" variant="h5">
                   <StyledContentEditable
                     onChange={event =>
                       handleOnChange({title: event.currentTarget.textContent})
@@ -50,14 +52,17 @@ export const CenterWindow = () => {
                   />
                 </Typography>
                 <StyledContentEditable
+                  aria-labelledby="editable-description"
                   sx={{color: 'text.secondary'}}
                   onChange={event =>
                     handleOnChange({
-                      description: event.currentTarget.textContent,
+                      properties: {
+                        description: event.currentTarget.textContent,
+                      },
                     })
                   }
                   data-placeholder="Write a desecription (optional)"
-                  html={`${selectedField.description}`}
+                  html={selectedField.properties.description || ''}
                 />
               </Stack>
               <RenderFields field={selectedField} />

--- a/app/src/features/ApplicationWorkspace/CenterWindow.tsx
+++ b/app/src/features/ApplicationWorkspace/CenterWindow.tsx
@@ -1,4 +1,4 @@
-import {Stack, styled, Typography} from '@mui/material';
+import {Container, Stack, styled, TextField, Typography} from '@mui/material';
 import ContentEdidable from 'react-contenteditable';
 
 import {useAppDispatch, useAppSelector} from '../../redux/hooks';
@@ -36,32 +36,32 @@ export const CenterWindow = () => {
             </Typography>
           </Stack>
         ) : (
-          <Stack>
-            <Typography variant="h5">
-              <StyledContentEditable
-                onChange={event =>
-                  handleOnInput({title: event.currentTarget.textContent})
-                }
-                contentEditable
-                data-placeholder="Write your question here"
-                suppressContentEditableWarning
-                html={selectedField.title}
-              />
-            </Typography>
-            <Typography variant="body1">
-              <StyledContentEditable
-                onChange={event =>
-                  handleOnInput({
-                    description: event.currentTarget.textContent,
-                  })
-                }
-                contentEditable
-                data-placeholder="Write a desecription (optional)"
-                suppressContentEditableWarning
-                html={selectedField.description}
-              />
-            </Typography>
-          </Stack>
+          <Container sx={{height: '100%'}} maxWidth="sm">
+            <Stack sx={{height: '100%'}} justifyContent={'center'} gap={3}>
+              <Stack>
+                <Typography variant="h5">
+                  <StyledContentEditable
+                    onChange={event =>
+                      handleOnInput({title: event.currentTarget.textContent})
+                    }
+                    data-placeholder="Write your question here"
+                    html={selectedField.title}
+                  />
+                </Typography>
+                <StyledContentEditable
+                  sx={{color: 'text.secondary'}}
+                  onChange={event =>
+                    handleOnInput({
+                      description: event.currentTarget.textContent,
+                    })
+                  }
+                  data-placeholder="Write a desecription (optional)"
+                  html={`${selectedField.description}`}
+                />
+              </Stack>
+              <TextField id="outlined" label="Outlined" variant="outlined" />
+            </Stack>
+          </Container>
         )}
       </StyledWindow>
     </Stack>

--- a/app/src/features/ApplicationWorkspace/CenterWindow.tsx
+++ b/app/src/features/ApplicationWorkspace/CenterWindow.tsx
@@ -1,0 +1,18 @@
+import {Stack} from '@mui/material';
+export const CenterWindow = () => {
+  return (
+    <Stack sx={{flex: 1, py: 10, px: 2}}>
+      <Stack
+        sx={{
+          height: '100%',
+          width: '100%',
+          aspectRatio: 'auto',
+          backgroundColor: 'background.default',
+          borderRadius: 2,
+          boxShadow:
+            'rgba(0, 0, 0, 0.08) 0px 2px 4px, rgba(0, 0, 0, 0.06) 0px 2px 12px;',
+        }}
+      ></Stack>
+    </Stack>
+  );
+};

--- a/app/src/features/ApplicationWorkspace/CenterWindow.tsx
+++ b/app/src/features/ApplicationWorkspace/CenterWindow.tsx
@@ -1,7 +1,8 @@
-import {Container, Stack, styled, TextField, Typography} from '@mui/material';
+import {Container, Stack, styled, Typography} from '@mui/material';
 import ContentEdidable from 'react-contenteditable';
 
 import {useAppDispatch, useAppSelector} from '../../redux/hooks';
+import {RenderFields} from './RenderApplicationFields';
 import {editField, Field} from './workspaceSlice';
 
 export const CenterWindow = () => {
@@ -10,7 +11,7 @@ export const CenterWindow = () => {
     workspace.fields.find(field => field.id === workspace.selectedId)
   );
 
-  const handleOnInput = (options: Partial<Field>) => {
+  const handleOnChange = (options: Partial<Field>) => {
     dispatch(
       editField({
         id: selectedField?.id,
@@ -42,7 +43,7 @@ export const CenterWindow = () => {
                 <Typography variant="h5">
                   <StyledContentEditable
                     onChange={event =>
-                      handleOnInput({title: event.currentTarget.textContent})
+                      handleOnChange({title: event.currentTarget.textContent})
                     }
                     data-placeholder="Write your question here"
                     html={selectedField.title}
@@ -51,7 +52,7 @@ export const CenterWindow = () => {
                 <StyledContentEditable
                   sx={{color: 'text.secondary'}}
                   onChange={event =>
-                    handleOnInput({
+                    handleOnChange({
                       description: event.currentTarget.textContent,
                     })
                   }
@@ -59,7 +60,7 @@ export const CenterWindow = () => {
                   html={`${selectedField.description}`}
                 />
               </Stack>
-              <TextField id="outlined" label="Outlined" variant="outlined" />
+              <RenderFields field={selectedField} />
             </Stack>
           </Container>
         )}

--- a/app/src/features/ApplicationWorkspace/CenterWindow.tsx
+++ b/app/src/features/ApplicationWorkspace/CenterWindow.tsx
@@ -48,7 +48,7 @@ export const CenterWindow = () => {
                 html={selectedField.title}
               />
             </Typography>
-            {/* <Typography variant="body1">
+            <Typography variant="body1">
               <StyledContentEditable
                 onChange={event =>
                   handleOnInput({
@@ -58,19 +58,9 @@ export const CenterWindow = () => {
                 contentEditable
                 data-placeholder="Write a desecription (optional)"
                 suppressContentEditableWarning
-                html={selectedField.title}
+                html={selectedField.description}
               />
-            </Typography> */}
-
-            {/* <StyledEditableText
-              onInput={handleOnInput}
-              contentEditable
-              variant="h5"
-              data-placeholder="Write your question here"
-              suppressContentEditableWarning
-            >
-              {selectedField.title}
-            </StyledEditableText> */}
+            </Typography>
           </Stack>
         )}
       </StyledWindow>

--- a/app/src/features/ApplicationWorkspace/CenterWindow.tsx
+++ b/app/src/features/ApplicationWorkspace/CenterWindow.tsx
@@ -74,7 +74,7 @@ const StyledWindow = styled(Stack)(({theme}) => ({
   width: '100%',
   aspectRatio: 'auto',
   backgroundColor: theme.palette.background.default,
-  borderRadius: 2,
+  borderRadius: 4,
   boxShadow:
     'rgba(0, 0, 0, 0.08) 0px 2px 4px, rgba(0, 0, 0, 0.06) 0px 2px 12px;',
 }));

--- a/app/src/features/ApplicationWorkspace/FieldIcons.tsx
+++ b/app/src/features/ApplicationWorkspace/FieldIcons.tsx
@@ -8,7 +8,7 @@ import {
   Subject,
 } from '@mui/icons-material';
 
-import {FieldTypes} from './constants';
+import {FieldTypes} from './workspaceSlice';
 
 interface FieldTypeOption {
   icon: React.ReactNode;

--- a/app/src/features/ApplicationWorkspace/FieldList.tsx
+++ b/app/src/features/ApplicationWorkspace/FieldList.tsx
@@ -8,10 +8,10 @@ import {
 import {MouseEvent as ReactMouseEvent} from 'react';
 
 import {FieldIcons} from './FieldIcons';
-import {Field} from './workspaceSlice';
+import {Fields} from './workspaceSlice';
 
 interface FieldListProps {
-  fields: Field[];
+  fields: Fields[];
   handleListItemClick: (
     event: ReactMouseEvent<HTMLDivElement, MouseEvent>,
     id: string

--- a/app/src/features/ApplicationWorkspace/FieldList.tsx
+++ b/app/src/features/ApplicationWorkspace/FieldList.tsx
@@ -26,22 +26,25 @@ export const FieldList = ({
 }: FieldListProps) => {
   return (
     <List sx={{px: 1}} aria-label="list of fields">
-      {fields.map(({id, type, title}) => (
-        <ListItem key={id} disableGutters disablePadding>
-          <ListItemButton
-            sx={{borderRadius: '8px'}}
-            aria-selected={selectedId === id}
-            selected={selectedId === id}
-            onClick={event => handleListItemClick(event, id)}
-            disableRipple
-          >
-            <ListItemIcon sx={{color: 'text.primary'}}>
-              {FieldIcons[type].icon}
-            </ListItemIcon>
-            <ListItemText primary={title} />
-          </ListItemButton>
-        </ListItem>
-      ))}
+      {fields.map(({id, type, title}) => {
+        const fieldTitle = title || '...';
+        return (
+          <ListItem key={id} disableGutters disablePadding>
+            <ListItemButton
+              sx={{borderRadius: '8px'}}
+              aria-selected={selectedId === id}
+              selected={selectedId === id}
+              onClick={event => handleListItemClick(event, id)}
+              disableRipple
+            >
+              <ListItemIcon sx={{color: 'text.primary'}}>
+                {FieldIcons[type].icon}
+              </ListItemIcon>
+              <ListItemText primary={fieldTitle} />
+            </ListItemButton>
+          </ListItem>
+        );
+      })}
     </List>
   );
 };

--- a/app/src/features/ApplicationWorkspace/FieldList.tsx
+++ b/app/src/features/ApplicationWorkspace/FieldList.tsx
@@ -31,16 +31,16 @@ export const FieldList = ({
         return (
           <ListItem key={id} disableGutters disablePadding>
             <ListItemButton
-              sx={{borderRadius: '8px'}}
+              sx={{borderRadius: '8px', gap: 2}}
               aria-selected={selectedId === id}
               selected={selectedId === id}
               onClick={event => handleListItemClick(event, id)}
               disableRipple
             >
-              <ListItemIcon sx={{color: 'text.primary'}}>
+              <ListItemIcon sx={{color: 'text.primary', minWidth: 'auto'}}>
                 {FieldIcons[type].icon}
               </ListItemIcon>
-              <ListItemText primary={fieldTitle} />
+              <ListItemText sx={{textWrap: 'wrap'}} primary={fieldTitle} />
             </ListItemButton>
           </ListItem>
         );

--- a/app/src/features/ApplicationWorkspace/FieldList.tsx
+++ b/app/src/features/ApplicationWorkspace/FieldList.tsx
@@ -7,8 +7,8 @@ import {
 } from '@mui/material';
 import {MouseEvent as ReactMouseEvent} from 'react';
 
-import {Field} from './constants';
 import {FieldIcons} from './FieldIcons';
+import {Field} from './workspaceSlice';
 
 interface FieldListProps {
   fields: Field[];

--- a/app/src/features/ApplicationWorkspace/LeftPanel.tsx
+++ b/app/src/features/ApplicationWorkspace/LeftPanel.tsx
@@ -4,9 +4,9 @@ import {MouseEvent as ReactMouseEvent} from 'react';
 
 import {useAppDispatch, useAppSelector} from '../../redux/hooks';
 import {AddFieldButton} from './AddFieldButton';
-import {FieldTypes} from './constants';
 import {FieldList} from './FieldList';
 import {PanelContainer} from './PanelContainer';
+import {FieldTypes} from './workspaceSlice';
 import {addField, Field, setSelectedId} from './workspaceSlice';
 
 export const LeftPanel = () => {
@@ -25,6 +25,7 @@ export const LeftPanel = () => {
     const newField: Field = {
       id: faker.string.uuid(),
       type: fieldType,
+      description: '',
       title: '',
     };
 

--- a/app/src/features/ApplicationWorkspace/LeftPanel.tsx
+++ b/app/src/features/ApplicationWorkspace/LeftPanel.tsx
@@ -25,7 +25,7 @@ export const LeftPanel = () => {
     const newField: Field = {
       id: faker.string.uuid(),
       type: fieldType,
-      title: '...',
+      title: '',
     };
 
     dispatch(addField(newField));

--- a/app/src/features/ApplicationWorkspace/LeftPanel.tsx
+++ b/app/src/features/ApplicationWorkspace/LeftPanel.tsx
@@ -7,7 +7,7 @@ import {AddFieldButton} from './AddFieldButton';
 import {FieldList} from './FieldList';
 import {PanelContainer} from './PanelContainer';
 import {FieldTypes} from './workspaceSlice';
-import {addField, Field, setSelectedId} from './workspaceSlice';
+import {addField, Fields, setSelectedId} from './workspaceSlice';
 
 export const LeftPanel = () => {
   const fields = useAppSelector(state => state.workspace.fields);
@@ -22,11 +22,14 @@ export const LeftPanel = () => {
   };
 
   const addFields = (fieldType: FieldTypes) => {
-    const newField: Field = {
+    const newField: Fields = {
       id: faker.string.uuid(),
       type: fieldType,
-      description: '',
       title: '',
+      properties: {
+        description: '',
+      },
+      validations: {},
     };
 
     dispatch(addField(newField));

--- a/app/src/features/ApplicationWorkspace/RenderApplicationFields.tsx
+++ b/app/src/features/ApplicationWorkspace/RenderApplicationFields.tsx
@@ -4,10 +4,10 @@ import {
   PhoneNumberField,
   ShortTextField,
 } from './ApplicationFields';
-import {Field} from './workspaceSlice';
+import {Fields} from './workspaceSlice';
 
 interface RenderFieldsProps {
-  field: Field;
+  field: Fields;
 }
 
 export const RenderFields = ({field}: RenderFieldsProps) => {

--- a/app/src/features/ApplicationWorkspace/RenderApplicationFields.tsx
+++ b/app/src/features/ApplicationWorkspace/RenderApplicationFields.tsx
@@ -17,7 +17,7 @@ export const RenderFields = ({field}: RenderFieldsProps) => {
     case 'long_text':
       return <LongTextField disabled />;
     case 'number':
-      return <PhoneNumberField disabled />;
+      return <PhoneNumberField />;
     case 'email':
       return <EmailField disabled />;
     default:

--- a/app/src/features/ApplicationWorkspace/RenderApplicationFields.tsx
+++ b/app/src/features/ApplicationWorkspace/RenderApplicationFields.tsx
@@ -1,0 +1,26 @@
+import {
+  EmailField,
+  LongTextField,
+  PhoneNumberField,
+  ShortTextField,
+} from './ApplicationFields';
+import {Field} from './workspaceSlice';
+
+interface RenderFieldsProps {
+  field: Field;
+}
+
+export const RenderFields = ({field}: RenderFieldsProps) => {
+  switch (field.type) {
+    case 'short_text':
+      return <ShortTextField disabled />;
+    case 'long_text':
+      return <LongTextField disabled />;
+    case 'number':
+      return <PhoneNumberField disabled />;
+    case 'email':
+      return <EmailField disabled />;
+    default:
+      throw new Error('Invalid field type');
+  }
+};

--- a/app/src/features/ApplicationWorkspace/__tests__/CenterWindow.test.tsx
+++ b/app/src/features/ApplicationWorkspace/__tests__/CenterWindow.test.tsx
@@ -1,0 +1,35 @@
+import {RootState} from '../../../redux/store';
+import {render, screen} from '../../../utils/test/test-utils';
+import {CenterWindow} from '../CenterWindow';
+import {fieldBuilder} from '../constants';
+
+const setup = (preloadedState: Partial<RootState> = {}) => {
+  const {container} = render(<CenterWindow />, {
+    preloadedState: {
+      workspace: {fields: [], selectedId: null},
+      ...preloadedState,
+    },
+  });
+
+  return {container};
+};
+
+describe('CenterWindow', () => {
+  test('renders the title, description and field for the selected component', () => {
+    const fields = Array.from(Array(3), () =>
+      fieldBuilder({
+        type: 'short_text',
+        properties: {description: 'description'},
+      })
+    );
+    setup({workspace: {fields, selectedId: fields[0].id}});
+
+    expect(screen.getByText(fields[0].title)).toBeInTheDocument();
+
+    if (fields[0].properties.description) {
+      expect(
+        screen.getByText(fields[0].properties.description)
+      ).toBeInTheDocument();
+    }
+  });
+});

--- a/app/src/features/ApplicationWorkspace/__tests__/RenderFields.test.tsx
+++ b/app/src/features/ApplicationWorkspace/__tests__/RenderFields.test.tsx
@@ -1,0 +1,33 @@
+import {render, screen} from '../../../utils/test/test-utils';
+import {fieldBuilder} from '../constants';
+import {RenderFields} from '../RenderApplicationFields';
+
+describe('RenderFields', () => {
+  test('renders short text field', () => {
+    const field = fieldBuilder({type: 'short_text'});
+    render(<RenderFields field={field} />);
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  test('renders long text field', () => {
+    const field = fieldBuilder({type: 'long_text'});
+    render(<RenderFields field={field} />);
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  test('renders phone number field', () => {
+    const field = fieldBuilder({type: 'number'});
+    render(<RenderFields field={field} />);
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  test('renders email field', () => {
+    const field = fieldBuilder({type: 'email'});
+    render(<RenderFields field={field} />);
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+});

--- a/app/src/features/ApplicationWorkspace/constants.ts
+++ b/app/src/features/ApplicationWorkspace/constants.ts
@@ -1,12 +1,13 @@
 import {faker} from '@faker-js/faker';
 
-import {fieldTypes} from './workspaceSlice';
+import {Field, fieldTypes} from './workspaceSlice';
 
-export const fieldBuilder = () => ({
+export const fieldBuilder = (options: Partial<Field>) => ({
   id: faker.string.numeric(4),
   title: faker.lorem.sentence(),
   description: faker.lorem.sentence(),
   type: faker.helpers.arrayElement(fieldTypes),
+  ...options,
 });
 
 // interface BaseProperties {

--- a/app/src/features/ApplicationWorkspace/constants.ts
+++ b/app/src/features/ApplicationWorkspace/constants.ts
@@ -1,28 +1,11 @@
 import {faker} from '@faker-js/faker';
 
-const fieldTypes = [
-  'short_text',
-  'long_text',
-  'number',
-  'email',
-  'dropdown',
-  'multiple_choice',
-  'yes_no',
-] as const;
-
-type FieldTypeTuple = typeof fieldTypes;
-
-export type FieldTypes = FieldTypeTuple[number];
-
-export interface Field {
-  id: string;
-  title: string;
-  type: FieldTypes;
-}
+import {fieldTypes} from './workspaceSlice';
 
 export const fieldBuilder = () => ({
   id: faker.string.numeric(4),
   title: faker.lorem.sentence(),
+  description: faker.lorem.sentence(),
   type: faker.helpers.arrayElement(fieldTypes),
 });
 

--- a/app/src/features/ApplicationWorkspace/constants.ts
+++ b/app/src/features/ApplicationWorkspace/constants.ts
@@ -1,37 +1,19 @@
 import {faker} from '@faker-js/faker';
 
-import {Field, fieldTypes} from './workspaceSlice';
+import {Fields, fieldTypes} from './workspaceSlice';
 
-export const fieldBuilder = (options: Partial<Field>) => ({
+export const fieldBuilder = (options: Partial<Fields> = {}): Fields => ({
   id: faker.string.numeric(4),
-  title: faker.lorem.sentence(),
-  description: faker.lorem.sentence(),
+  title: faker.lorem.sentence({min: 5, max: 10}),
   type: faker.helpers.arrayElement(fieldTypes),
   ...options,
+  properties: {
+    ...options.properties,
+  },
+  validations: {
+    ...options.validations,
+  },
 });
-
-// interface BaseProperties {
-//   description?: string;
-// }
-
-// interface BaseValidations {
-//   required: boolean;
-// }
-
-// interface BaseField {
-//   id: string;
-//   title: string;
-//   type: FieldTypes;
-//   properties: BaseProperties;
-//   validations: BaseValidations;
-// }
-
-// export interface ShortTextField extends BaseField {
-//   validations: {
-//     required: boolean;
-//     max_length?: number;
-//   };
-// }
 
 export const fields = {
   fields: [

--- a/app/src/features/ApplicationWorkspace/workspaceSlice.ts
+++ b/app/src/features/ApplicationWorkspace/workspaceSlice.ts
@@ -21,13 +21,6 @@ export interface Field {
   type: FieldTypes;
 }
 
-export interface Field {
-  id: string;
-  title: string;
-  description: string;
-  type: FieldTypes;
-}
-
 interface WorkspaceState {
   selectedId: string | null;
   fields: Field[];

--- a/app/src/features/ApplicationWorkspace/workspaceSlice.ts
+++ b/app/src/features/ApplicationWorkspace/workspaceSlice.ts
@@ -35,9 +35,15 @@ const workspaceSlice = createSlice({
     addField: (state, action: PayloadAction<Field>) => {
       state.fields.push(action.payload);
     },
+    editField: (state, action: PayloadAction<Partial<Field>>) => {
+      const {id, ...field} = action.payload;
+      const index = state.fields.findIndex(field => field.id === id);
+      const currField = state.fields[index];
+      state.fields[index] = {...currField, ...field};
+    },
   },
 });
 
 const {actions, reducer} = workspaceSlice;
-export const {setSelectedId, addField} = actions;
+export const {setSelectedId, addField, editField} = actions;
 export default reducer;

--- a/app/src/features/ApplicationWorkspace/workspaceSlice.ts
+++ b/app/src/features/ApplicationWorkspace/workspaceSlice.ts
@@ -1,5 +1,6 @@
 import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 
+// Types of Fields
 export const fieldTypes = [
   'short_text',
   'long_text',
@@ -14,17 +15,131 @@ type FieldTypeTuple = typeof fieldTypes;
 
 export type FieldTypes = FieldTypeTuple[number];
 
-export interface Field {
+// Base Types for fields, properties, and validations
+type FieldProperties =
+  | BaseProperties
+  | DropdownFieldProperties
+  | MultipleChoiceFieldProperties;
+
+type FieldValidations =
+  | BaseValidations
+  | ShortTextFieldValidations
+  | LongTextFieldValidations;
+
+// interface FieldBase {
+//   id: string;
+//   title: string;
+//   type: FieldTypes;
+//   properties: {
+//     description?: string;
+//     randomize?: boolean;
+//     alphabetical_order?: boolean;
+//     allow_multiple_selection?: boolean;
+//     allow_other_choice?: boolean;
+//     choices?: {
+//       id: string;
+//       label: string;
+//     }[];
+//   };
+//   validations: {
+//     required?: boolean;
+//     max_characters?: number;
+//   };
+// }
+
+interface BaseField<
+  T extends FieldTypes,
+  P extends FieldProperties,
+  V extends FieldValidations,
+> {
   id: string;
   title: string;
-  description: string;
-  type: FieldTypes;
+  type: T;
+  properties: P;
+  validations: V;
 }
+
+interface BaseProperties {
+  description?: string;
+}
+
+interface BaseValidations {
+  required?: boolean;
+}
+
+//Space Types for properties
+interface DropdownFieldProperties extends BaseProperties {
+  randomize?: boolean;
+  alphabetical_order?: boolean;
+  choices?: {
+    id: string;
+    label: string;
+  }[];
+}
+
+interface MultipleChoiceFieldProperties extends BaseProperties {
+  randomize?: boolean;
+  allow_multiple_selection?: boolean;
+  allow_other_choice?: boolean;
+  choices?: {
+    id: string;
+    label: string;
+  }[];
+}
+
+// Specific Types for validations
+interface ShortTextFieldValidations extends BaseValidations {
+  max_characters?: number;
+}
+interface LongTextFieldValidations extends BaseValidations {
+  max_characters?: number;
+}
+
+// Specific Types for fields
+type ShortTextField = BaseField<
+  'short_text',
+  BaseProperties,
+  ShortTextFieldValidations
+>;
+
+type LongTextField = BaseField<
+  'long_text',
+  BaseProperties,
+  LongTextFieldValidations
+>;
+
+type EmailField = BaseField<'email', BaseProperties, BaseValidations>;
+
+type PhoneNumberField = BaseField<'number', BaseProperties, BaseValidations>;
+
+type YesNoField = BaseField<'yes_no', BaseProperties, BaseValidations>;
+
+type DropdownField = BaseField<
+  'dropdown',
+  DropdownFieldProperties,
+  BaseValidations
+>;
+
+type MultipleChoiceField = BaseField<
+  'multiple_choice',
+  MultipleChoiceFieldProperties,
+  BaseValidations
+>;
+export type Fields =
+  | ShortTextField
+  | LongTextField
+  | EmailField
+  | PhoneNumberField
+  | YesNoField
+  | DropdownField
+  | MultipleChoiceField;
 
 interface WorkspaceState {
   selectedId: string | null;
-  fields: Field[];
+  fields: Fields[];
 }
+
+// type Expand<T> = T extends infer O ? {[K in keyof O]: O[K]} : never;
 
 const initialState: WorkspaceState = {
   selectedId: null,
@@ -38,14 +153,32 @@ const workspaceSlice = createSlice({
     setSelectedId: (state, action) => {
       state.selectedId = action.payload;
     },
-    addField: (state, action: PayloadAction<Field>) => {
+    addField: (state, action: PayloadAction<Fields>) => {
       state.fields.push(action.payload);
     },
-    editField: (state, action: PayloadAction<Partial<Field>>) => {
-      const {id, ...field} = action.payload;
+    editField: (state, action: PayloadAction<Partial<Fields>>) => {
+      const {id} = action.payload;
       const index = state.fields.findIndex(field => field.id === id);
       const currField = state.fields[index];
-      state.fields[index] = {...currField, ...field};
+      state.fields.splice(index, 1, {
+        ...currField,
+        ...action.payload,
+        properties: {...currField.properties, ...action.payload.properties},
+        validations: {...currField.validations, ...action.payload.validations},
+      });
+    },
+    editTitle: (state, action: PayloadAction<{id: string; title: string}>) => {
+      const {id, title} = action.payload;
+      const index = state.fields.findIndex(field => field.id === id);
+      state.fields[index].title = title;
+    },
+    editDescription: (
+      state,
+      action: PayloadAction<{id: string; description: string}>
+    ) => {
+      const {id, description} = action.payload;
+      const index = state.fields.findIndex(field => field.id === id);
+      state.fields[index].properties.description = description;
     },
   },
 });

--- a/app/src/features/ApplicationWorkspace/workspaceSlice.ts
+++ b/app/src/features/ApplicationWorkspace/workspaceSlice.ts
@@ -1,17 +1,30 @@
 import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 
-export type FieldTypes =
-  | 'short_text'
-  | 'long_text'
-  | 'number'
-  | 'email'
-  | 'dropdown'
-  | 'multiple_choice'
-  | 'yes_no';
+export const fieldTypes = [
+  'short_text',
+  'long_text',
+  'number',
+  'email',
+  'dropdown',
+  'multiple_choice',
+  'yes_no',
+] as const;
+
+type FieldTypeTuple = typeof fieldTypes;
+
+export type FieldTypes = FieldTypeTuple[number];
 
 export interface Field {
   id: string;
   title: string;
+  description: string;
+  type: FieldTypes;
+}
+
+export interface Field {
+  id: string;
+  title: string;
+  description: string;
   type: FieldTypes;
 }
 

--- a/app/src/services/generatedApi.ts
+++ b/app/src/services/generatedApi.ts
@@ -39,6 +39,7 @@ export type PostApplicationApiArg = {
     name: string;
   };
 };
+
 export type GetApplicationByApplicationIdApiResponse =
   /** status 200 application response */ {
     id: string;

--- a/app/src/views/ApplicationWorkspace.tsx
+++ b/app/src/views/ApplicationWorkspace.tsx
@@ -1,6 +1,7 @@
 import {CircularProgress, Stack, Typography} from '@mui/material';
 import {useParams} from 'react-router-dom';
 
+import {CenterWindow} from '../features/ApplicationWorkspace/CenterWindow';
 import {LeftPanel} from '../features/ApplicationWorkspace/LeftPanel';
 import {useGetApplicationByApplicationIdQuery} from '../services/generatedApi';
 
@@ -39,19 +40,7 @@ export const ApplicationWorkspace = () => {
       ) : (
         <>
           <LeftPanel />
-          <Stack sx={{flex: 1, py: 10, px: 2}}>
-            <Stack
-              sx={{
-                height: '100%',
-                width: '100%',
-                aspectRatio: 'auto',
-                backgroundColor: 'background.default',
-                borderRadius: 2,
-                boxShadow:
-                  'rgba(0, 0, 0, 0.08) 0px 2px 4px, rgba(0, 0, 0, 0.06) 0px 2px 12px;',
-              }}
-            ></Stack>
-          </Stack>
+          <CenterWindow />
           <Stack
             sx={{
               p: 2,


### PR DESCRIPTION
This PR includes the following changes: 

- Creates the center window component that renders an editable title and description
- A switch statement that renders the field component based on its type. I started with the short text, long text, and email fields and the rest will added in future PRs
- Made adjustments to the definitions for fields to make them more restrictive based on the field type